### PR TITLE
Fixes to make it compile only NMNSC/MRX

### DIFF
--- a/bchain/coins/mrx/qtumparser.go
+++ b/bchain/coins/mrx/qtumparser.go
@@ -1,9 +1,9 @@
 package mrx
 
 import (
-	"blockbook/bchain"
-	"blockbook/bchain/coins/btc"
-	"blockbook/bchain/coins/utils"
+	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/bchain/coins/btc"
+	"github.com/trezor/blockbook/bchain/coins/utils"
 	"bytes"
 	"encoding/json"
 	"io"

--- a/bchain/coins/mrx/qtumrpc.go
+++ b/bchain/coins/mrx/qtumrpc.go
@@ -1,11 +1,12 @@
 package mrx
 
 import (
-	"blockbook/bchain"
-	"blockbook/bchain/coins/btc"
+	"github.com/trezor/blockbook/bchain"
+	"github.com/trezor/blockbook/bchain/coins/btc"
 	"encoding/json"
 
 	"github.com/golang/glog"
+
 )
 
 // QtumRPC is an interface to JSON-RPC bitcoind service.

--- a/build/docker/bin/Dockerfile
+++ b/build/docker/bin/Dockerfile
@@ -46,8 +46,9 @@ RUN \
     trap cleanup EXIT && \
     mkdir -p $GOPATH/src/github.com/trezor && \
     cd $GOPATH/src/github.com/trezor && \
-    git clone https://github.com/trezor/blockbook.git && \
+    git clone https://github.com/Liquid369/blockbook.git && \
     cd blockbook && \
+    git checkout origin/origin/fls_test && \
     go mod download
 
 ADD Makefile /build/Makefile

--- a/build/docker/deb/Dockerfile
+++ b/build/docker/deb/Dockerfile
@@ -5,6 +5,7 @@ FROM blockbook-build:latest
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y devscripts debhelper make dh-systemd dh-exec && \
+    git config --global --add safe.directory /src && \
     apt-get clean
 
 ADD gpg-keys /tmp/gpg-keys

--- a/configs/coins/nmnsc.json
+++ b/configs/coins/nmnsc.json
@@ -1,15 +1,15 @@
 {
     "coin": {
-      "name": "METRIX",
-      "shortcut": "MRX",
-      "label": "MRX",
-      "alias": "metrix"
+      "name": "NMNSC",
+      "shortcut": "nMNSC",
+      "label": "NMNSC",
+      "alias": "nmnsc"
     },
     "ports": {
-      "backend_rpc": 8050,
-      "backend_message_queue": 38350,
-      "blockbook_internal": 9050,
-      "blockbook_public": 9150
+      "backend_rpc": 8049,
+      "backend_message_queue": 38349,
+      "blockbook_internal": 9049,
+      "blockbook_public": 9149
     },
     "ipc": {
       "rpc_url_template": "http://127.0.0.1:{{.Ports.BackendRPC}}",
@@ -19,14 +19,18 @@
       "message_queue_binding_template": "tcp://127.0.0.1:{{.Ports.BackendMessageQueue}}"
     },
     "backend": {
-      "package_name": "backend-mrx",
+      "package_name": "backend-nmnsc",
       "package_revision": "satoshilabs-1",
-      "system_user": "mrx",
-      "version": "4.2.0.1",
-      "binary_url": "https://github.com/TheLindaProjectInc/Metrix/releases/download/4.2.0.1/metrix-linux-x64.tar.gz",
-      "extract_command": "tar -C backend -xf",
-      "exclude_files": ["qt/metrix-qt"],
-      "exec_command_template": "{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/bin/metrixd -datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend -conf={{.Env.BackendInstallPath}}/{{.Coin.Alias}}/{{.Coin.Alias}}.conf -paramsdir={{.Env.BackendInstallPath}}/{{.Coin.Alias}}/share/metrix -pid=/run/{{.Coin.Alias}}/{{.Coin.Alias}}.pid",
+      "system_user": "nmnsc",
+      "version": "1.0.0",
+      "binary_url": "https://github.com/NewMNSavings/NewMNSCoin/releases/download/v1.0.0/nMNSC-Ubuntu20.zip",
+      "verification_type": "sha256",
+      "verification_source": "ecfeb225ded15a6b826633bad4175d1aa5152c5c31062cf884e36e21e7a610df",
+      "extract_command": "unzip -d backend",
+      "exclude_files": [
+        "nmnsc-qt"
+      ],
+      "exec_command_template": "{{.Env.BackendInstallPath}}/{{.Coin.Alias}}/bin/nmnscd -datadir={{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend -conf={{.Env.BackendInstallPath}}/{{.Coin.Alias}}/{{.Coin.Alias}}.conf -paramsdir={{.Env.BackendInstallPath}}/{{.Coin.Alias}}/share/nmnsc -pid=/run/{{.Coin.Alias}}/{{.Coin.Alias}}.pid",
       "logrotate_files_template": "{{.Env.BackendDataPath}}/{{.Coin.Alias}}/backend/*.log",
       "postinst_script_template": "",
       "service_type": "forking",
@@ -40,8 +44,8 @@
       }
     },
     "blockbook": {
-      "package_name": "blockbook-mrx",
-      "system_user": "blockbook-mrx",
+      "package_name": "blockbook-nmnsc",
+      "system_user": "blockbook-nmnsc",
       "internal_binding_template": ":{{.Ports.BlockbookInternal}}",
       "public_binding_template": ":{{.Ports.BlockbookPublic}}",
       "explorer_url": "",
@@ -51,7 +55,8 @@
         "mempool_workers": 8,
         "mempool_sub_workers": 2,
         "block_addresses_to_keep": 300,
-        "xpub_magic": 76067358,
+        "xpub_magic": 36513139,
+        "slip44": 7676,
         "additional_params": {}
       }
     },

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.5 // indirect
 	github.com/tklauser/numcpus v0.2.2 // indirect
 	golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 // indirect
-	google.golang.org/protobuf v1.23.0 // indirect
+	google.golang.org/protobuf v1.23 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 )
 


### PR DESCRIPTION
We still will need to add scc and there were some weird issues I was getting when trying to build all of a coin (kyd times out) and the pivxparser_test.go, but that doesn't stop us from getting this up and running for now for these specific coins